### PR TITLE
[ptn] removed git-describe.h from tracking

### DIFF
--- a/Source/EditorTools/Private/git-describe.h
+++ b/Source/EditorTools/Private/git-describe.h
@@ -1,1 +1,0 @@
-#define GIT_DESCRIBE 19ae749-dirty 


### PR DESCRIPTION
@daricalouie can you please merge this so that git-describe.h stops showing up as modified every time plugin is compiled?